### PR TITLE
allow open reads on Messages so that syncs can sync other people's messages

### DIFF
--- a/amplify/backend/api/allamplifychatt/schema.graphql
+++ b/amplify/backend/api/allamplifychatt/schema.graphql
@@ -27,7 +27,7 @@ type Conversation
 
 type Message 
   @model(subscriptions: null, queries: null) 
-  @auth(rules: [{ allow: owner, ownerField: "authorId" }]) {
+  @auth(rules: [{ allow: owner, ownerField: "authorId", operations: [create, update, delete]}]) {
   id: ID!
   author: User @connection(name: "UserMessages", keyField: "authorId")
   authorId: String


### PR DESCRIPTION
allow open reads on Messages, fixes https://github.com/aws-samples/aws-appsync-chat/issues/6

*Issue #, if available:* https://github.com/aws-samples/aws-appsync-chat/issues/6

*Description of changes:* specifies auth operations on Messages so that reads are not auth required.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
